### PR TITLE
Fix fast BPM and potential note-drifting

### DIFF
--- a/music/automusic.py
+++ b/music/automusic.py
@@ -1,33 +1,35 @@
+import codecs
 import json
 import time
+from multiprocessing import Manager, Value
+
+import chardet
 import keyboard
 import pydirectinput
-import codecs
 import pygetwindow as gw
-import chardet
-from multiprocessing import Value, Manager
+
 
 def convert_to_utf8(input_file, output_file):
     """
     Convert a JSON file from any encoding to UTF-8.
-    
+
     Args:
     input_file (str): Path to the input JSON file.
     output_file (str): Path to the output JSON file.
     """
 
-    with open(input_file, 'rb') as file:
+    with open(input_file, "rb") as file:
         raw_data = file.read()
-    
-    detected_encoding = chardet.detect(raw_data)['encoding']
-    if detected_encoding == 'UTF-8':
+
+    detected_encoding = chardet.detect(raw_data)["encoding"]
+    if detected_encoding == "UTF-8":
         return
 
     decoded_data = raw_data.decode(detected_encoding)
 
     json_data = json.loads(decoded_data)
 
-    with open(output_file, 'w', encoding='utf-8') as file:
+    with open(output_file, "w", encoding="utf-8") as file:
         json.dump(json_data, file, ensure_ascii=False, indent=4)
 
 
@@ -42,18 +44,17 @@ class MusicHandler:
         self.config = config
         self.data = self.read_json_file(file_path)
 
-        notes = self.data[0]['songNotes']
-        bpm = self.data[0]['bpm']
+        notes = self.data[0]["songNotes"]
+        bpm = self.data[0]["bpm"]
         self.start_key, self.stop_key = self.get_hotkeys()
 
         keyboard.add_hotkey(self.stop_key, lambda: self.pause())
         while not self.exitProgram:
-                keyboard.wait(self.start_key)
-                self.pauseProgram = False
-                time.sleep(2)
-                if gw.getActiveWindowTitle() == 'Sky':
-                    self.simulate_keyboard_presses(notes, bpm, max_notes, curr_note)
-    
+            keyboard.wait(self.start_key)
+            self.pauseProgram = False
+            time.sleep(2)
+            if gw.getActiveWindowTitle() == "Sky":
+                self.simulate_keyboard_presses(notes, bpm, max_notes, curr_note)
 
     def get_hotkeys(self):
         keys = self.config.read_config()["music"]
@@ -61,18 +62,20 @@ class MusicHandler:
 
     def read_json_file(self, file_path):
         convert_to_utf8(self.file_path, self.file_path)
-        with codecs.open(file_path, 'r', 'utf-8', 'ignore') as file:
+        with codecs.open(file_path, "r", "utf-8", "ignore") as file:
             try:
                 return json.load(file)
             except json.JSONDecodeError:
-                raise ValueError(f"Invalid JSON file: {file_path}. Probably wrong encoding, please make sure that your file is in UTF-8.")
-    
+                raise ValueError(
+                    f"Invalid JSON file: {file_path}. Probably wrong encoding, please make sure that your file is in UTF-8."
+                )
+
     def quit(self):
-        self.exitProgram=True
-    
+        self.exitProgram = True
+
     def pause(self):
         self.pauseProgram = True
-    
+
     def simulate_keyboard_presses(self, notes, bpm, max_notes, curr_note):
 
         hold_time = 0.05
@@ -81,37 +84,52 @@ class MusicHandler:
 
         notes_dict = {}
         for note in notes:
-            if note['time'] in notes_dict:
-                notes_dict[note['time']].append(key_mapping.get(note['key'][4:]))
+            if note["time"] in notes_dict:
+                notes_dict[note["time"]].append(key_mapping.get(note["key"][4:]))
             else:
-                notes_dict[note['time']] = [key_mapping.get(note['key'][4:])]
+                notes_dict[note["time"]] = [key_mapping.get(note["key"][4:])]
         notes = list(notes_dict.items())
-    
-
-        beat_interval = 60 / bpm  # Seconds per beat
 
         last_time_ms = 0
-        pydirectinput.PAUSE=None
+        pydirectinput.PAUSE = None
 
         max_notes.value = len(notes)
         curr_note.value = 0
 
+        start_time = time.perf_counter()
+        paused_time = 0.0
+        pause_start = None
+
         for note in notes:
-            if self.pauseProgram: break
-            current_time_ms = note[0]
-            if last_time_ms != 0:
-                time_delay = (current_time_ms - last_time_ms) / 1000.0
-            else:
-                time_delay = current_time_ms / 1000.0
+            target_time = note[0] / 1000.0
 
-            time.sleep(time_delay * beat_interval)
+            while True:
+                # Handle pausing
+                if self.pauseProgram:
+                    if pause_start is None:
+                        pause_start = time.perf_counter()
 
-            key_to_press = note[1]
-            if key_to_press:
-                pydirectinput.hotkey(*key_to_press, wait=hold_time)
-                curr_note.value += 1
+                    time.sleep(0.01)
+                    continue
 
-            last_time_ms = current_time_ms
+                # Resume
+                if pause_start is not None:
+                    paused_time += time.perf_counter() - pause_start
+                    pause_start = None
+
+                elapsed = time.perf_counter() - start_time
+                remaining = target_time - elapsed
+
+                if remaining <= 0:
+                    break
+
+                time.sleep(min(remaining, 0.001))
+
+            if self.pauseProgram:
+                    continue
+
+            pydirectinput.hotkey(*note[1], wait=hold_time)
+
 
 def mstart(file, max_notes, curr_note, config):
     ms = MusicHandler(file, max_notes, curr_note, config)


### PR DESCRIPTION
This PR changes two aspects:
- The BPM calculation has been fixed to be not too fast
- The way time is measured has been adjusted. Rather than calculating the note gap and passing that to sleep, it now uses a timestamp from the start and calculates the time this way. By doing it this way, some notes appearing slightly too fast or too slow should be fixed too.

Also, apologies for the code formatting that appeared. That is my code editor (Zed) doing it by default _(tbf it is looking better like that though. Oh welp…)__

Related to Issue #3 